### PR TITLE
Remove shortened array syntax (PHP 5.4 feature)

### DIFF
--- a/src/app/code/community/SchumacherFM/Markdown/Model/Options/Styles/AbstractStyles.php
+++ b/src/app/code/community/SchumacherFM/Markdown/Model/Options/Styles/AbstractStyles.php
@@ -7,7 +7,7 @@
  */
 abstract class SchumacherFM_Markdown_Model_Options_Styles_AbstractStyles
 {
-    protected $_path = [];
+    protected $_path = array();
 
     /**
      * Options getter


### PR DESCRIPTION
Quick fix but will result in PHP 5.2 being supported as stated in the readme. You might want to bump that up to PHP 5.3 as listed on the PHP downloads page.
