### PR TITLE
ACL/Adminhtml fix following Magento security patch SUPEE-6285

### DIFF
--- a/src/app/code/community/SchumacherFM/Markdown/controllers/Adminhtml/MarkdownController.php
+++ b/src/app/code/community/SchumacherFM/Markdown/controllers/Adminhtml/MarkdownController.php
@@ -137,4 +137,9 @@ class SchumacherFM_Markdown_Adminhtml_MarkdownController extends Mage_Adminhtml_
     {
         return Mage::getConfig()->getOptions()->getMediaDir() . DS;
     }
+
+    protected function _isAllowed()
+    {
+        return Mage::getSingleton('admin/session')->isAllowed('markdown_editor');
+    }
 }


### PR DESCRIPTION
Following SUPEE-6285, classes extending Mage_Adminhtml_Controller_Action need to explicitly provide an isAllowed override to correctly use ACL permissions and avoid access denied for admin roles with custom resource permissions.

More here: http://magento.stackexchange.com/questions/73646/access-denied-errors-after-installing-supee-6285